### PR TITLE
Alleviate script warnings and update zerk check for melee weapons.

### DIFF
--- a/ZScript/Misc/ItemSpawns.zsc
+++ b/ZScript/Misc/ItemSpawns.zsc
@@ -141,8 +141,9 @@ class PB_HDAutoMagSpawn_FA:IdleDummy{
 	states{
 	spawn:
 		TNT1 A 0 nodelay{
-			let www=HD_AutoMagFA(spawn("HD_AutoMagFA",pos,ALLOW_REPLACE));
+			HD_AutoMag www=HD_AutoMag(spawn("HD_AutoMag",pos,ALLOW_REPLACE));
 			HDF.TransferSpecials(self,www,HDF.TS_ALL);
+			if(www)www.weaponstatus[0]|=PI5F_SELECTFIRE;
 
 				spawn("HD50AM_Mag",pos+(10,0,0),ALLOW_REPLACE);
 				spawn("HD50AM_Mag",pos+(8,0,0),ALLOW_REPLACE);

--- a/ZScript/Weapons/CAWS/CAWS.zsc
+++ b/ZScript/Weapons/CAWS/CAWS.zsc
@@ -186,7 +186,7 @@ class HD_CAWSGUN:HDShotgun{
 		HDStatusBar sb,HDWeapon hdw,HDPlayerPawn hpl,
 		bool sightbob,vector2 bob,double fov,bool scopeview,actor hpc,string whichdot
 	){
-		int scaledyoffset=41.9;
+		float scaledyoffset=41.9;
 
 		{
 		vector2 bobb=bob*1.25;

--- a/ZScript/Weapons/Kelenken/KelenkenBox.zsc
+++ b/ZScript/Weapons/Kelenken/KelenkenBox.zsc
@@ -71,7 +71,7 @@ class HD_PB_35mmBeltBox:HDMagAmmo{
 		)return false;
 		owner.A_TakeInventory(roundtype,1,TIF_NOTAKEINFINITE);
 		owner.A_TakeInventory("HD_35mmBeltLink",1,TIF_NOTAKEINFINITE);
-		owner.A_PlaySound("weapons/rifleclick2",CHAN_WEAPON);
+		owner.A_StartSound("weapons/rifleclick2",CHAN_WEAPON);
 		mags[mags.size()-1]++;
 		
 			inserttime=25;

--- a/ZScript/Weapons/M2HB/M2HBBox.zsc
+++ b/ZScript/Weapons/M2HB/M2HBBox.zsc
@@ -110,7 +110,7 @@ class HD_PB_50OMGBeltBox:HDMagAmmo{
 		)return false;
 		owner.A_TakeInventory(roundtype,1,TIF_NOTAKEINFINITE);
 		owner.A_TakeInventory("HD_12MMBeltLink",1,TIF_NOTAKEINFINITE);
-		owner.A_PlaySound("weapons/rifleclick2",CHAN_WEAPON);
+		owner.A_StartSound("weapons/rifleclick2",CHAN_WEAPON);
 		mags[mags.size()-1]++;
 		
 			inserttime=11;

--- a/ZScript/Weapons/Melee/HDFireAxe.zsc
+++ b/ZScript/Weapons/Melee/HDFireAxe.zsc
@@ -344,8 +344,8 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 		A_Recoil(-3);
 	}
 	static void kick(actor kicker,actor kickee,actor kicking){
-		kickee.A_PlaySound("weapons/smack",CHAN_BODY);
-		bool kzk=kicker.countinv("HDZerk");
+		kickee.A_StartSound("weapons/smack",CHAN_BODY);
+		bool kzk=kicker.countinv("HDZerk")>HDZERK_COOLOFF;
 		kickee.damagemobj(kicking,kicker,kzk?random(20,40):random(10,20),"bashing");
 		if(kickee&&!kickee.bnopain&&kickee.health>0&&random(0,4))kickee.setstatelabel("pain");
 		vector3 kickdir=(kickee.pos-kicker.pos).unit();
@@ -391,7 +391,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 	althold:
 		TNT1 A 0;
 	startfire:
-		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswingstart");
+		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerkswingstart");
 		FAX0 A 0 A_StartSound("weapons/pocket",CHAN_6);
 		FAX0 A 0;
 		FAX0 BC 3;
@@ -420,7 +420,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 		TNT1 A 5 A_StartSound("weapons/pocket",CHAN_6);
 	goto holdswing;
 	swing:
-		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswing");
+		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerkswing");
 		FAX0 A 0 A_StartSound("weapons/axeswing",CHAN_7);
 		FAX0 DE 1;
 		#### D 0 A_Overlay(5,"hitcheck",false);
@@ -480,7 +480,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 	lunge2:
 		TNT1 A 0 A_Lunge();
 		TNT1 AA 1{
-			if(countinv("HDZerk"))A_Recoil(-random(12,24));
+			if(countinv("HDZerk")>HDZERK_COOLOFF)A_Recoil(-random(12,24));
 		}
 		TNT1 A 1 A_Recoil(-4);
 		stop;

--- a/ZScript/Weapons/Melee/HDFireAxe.zsc
+++ b/ZScript/Weapons/Melee/HDFireAxe.zsc
@@ -214,18 +214,18 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 		}
 
 		//actual puff effect if the shot connects
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")?"WallChunker":"WallChunker",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>HDZERK_COOLOFF?"WallChunker":"WallChunker",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 			
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")?"HDSmokeChunk":"BulletPuffSmall",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>HDZERK_COOLOFF?"HDSmokeChunk":"BulletPuffSmall",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 		
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")?"HDAxePuff":"HDAxePuff",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>HDZERK_COOLOFF?"HDAxePuff":"HDAxePuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
 			
@@ -320,8 +320,8 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 		if(punchee.health>0)punchee.damagemobj(self,self,int(dmg),"SmallArms3");
 		else punchee.damagemobj(self,self,int(dmg*1.5),"SmallArms3");
 		
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")?"HDAxePuff":"HDAxePuff",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>HDZERK_COOLOFF?"HDAxePuff":"HDAxePuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 

--- a/ZScript/Weapons/Melee/HDFireAxe.zsc
+++ b/ZScript/Weapons/Melee/HDFireAxe.zsc
@@ -214,18 +214,18 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 		}
 
 		//actual puff effect if the shot connects
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")>HDZERK_COOLOFF?"WallChunker":"WallChunker",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>PBZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>PBZERK_COOLOFF?"WallChunker":"WallChunker",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 			
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")>HDZERK_COOLOFF?"HDSmokeChunk":"BulletPuffSmall",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>PBZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>PBZERK_COOLOFF?"HDSmokeChunk":"BulletPuffSmall",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 		
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")>HDZERK_COOLOFF?"HDAxePuff":"HDAxePuff",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>PBZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>PBZERK_COOLOFF?"HDAxePuff":"HDAxePuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
 			
@@ -320,8 +320,8 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 		if(punchee.health>0)punchee.damagemobj(self,self,int(dmg),"SmallArms3");
 		else punchee.damagemobj(self,self,int(dmg*1.5),"SmallArms3");
 		
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")>HDZERK_COOLOFF?"HDAxePuff":"HDAxePuff",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>PBZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>PBZERK_COOLOFF?"HDAxePuff":"HDAxePuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 
@@ -345,7 +345,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 	}
 	static void kick(actor kicker,actor kickee,actor kicking){
 		kickee.A_StartSound("weapons/smack",CHAN_BODY);
-		bool kzk=kicker.countinv("HDZerk")>HDZERK_COOLOFF;
+		bool kzk=kicker.countinv("HDZerk")>PBZERK_COOLOFF;
 		kickee.damagemobj(kicking,kicker,kzk?random(20,40):random(10,20),"bashing");
 		if(kickee&&!kickee.bnopain&&kickee.health>0&&random(0,4))kickee.setstatelabel("pain");
 		vector3 kickdir=(kickee.pos-kicker.pos).unit();
@@ -391,7 +391,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 	althold:
 		TNT1 A 0;
 	startfire:
-		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerkswingstart");
+		#### A 0 A_JumpIfInventory("HDZerk",PBZERK_COOLOFF,"zerkswingstart");
 		FAX0 A 0 A_StartSound("weapons/pocket",CHAN_6);
 		FAX0 A 0;
 		FAX0 BC 3;
@@ -420,7 +420,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 		TNT1 A 5 A_StartSound("weapons/pocket",CHAN_6);
 	goto holdswing;
 	swing:
-		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerkswing");
+		#### A 0 A_JumpIfInventory("HDZerk",PBZERK_COOLOFF,"zerkswing");
 		FAX0 A 0 A_StartSound("weapons/axeswing",CHAN_7);
 		FAX0 DE 1;
 		#### D 0 A_Overlay(5,"hitcheck",false);
@@ -480,7 +480,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 	lunge2:
 		TNT1 A 0 A_Lunge();
 		TNT1 AA 1{
-			if(countinv("HDZerk")>HDZERK_COOLOFF)A_Recoil(-random(12,24));
+			if(countinv("HDZerk")>PBZERK_COOLOFF)A_Recoil(-random(12,24));
 		}
 		TNT1 A 1 A_Recoil(-4);
 		stop;

--- a/ZScript/Weapons/Melee/HDGrossHack.zsc
+++ b/ZScript/Weapons/Melee/HDGrossHack.zsc
@@ -1,3 +1,4 @@
+const PBZERK_COOLOFF=10500; //for zerk checks
 
 class HD_PB_UnarmedWeapon:HDFist{
 	default{

--- a/ZScript/Weapons/Melee/HDKharon.zsc
+++ b/ZScript/Weapons/Melee/HDKharon.zsc
@@ -243,17 +243,17 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		);
 		
 		//actual puff effect if the shot connects
-		/*LineAttack(angle+pb_angle,pb_range,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")?"WallChunker":"WallChunker",
+		/*LineAttack(angle+pb_angle,pb_range,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>HDZERK_COOLOFF?"WallChunker":"WallChunker",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 			
-		LineAttack(angle+pb_angle,pb_range,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")?"HDSmokeChunk":"BulletPuffSmall",
+		LineAttack(angle+pb_angle,pb_range,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>HDZERK_COOLOFF?"HDSmokeChunk":"BulletPuffSmall",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);*/
 		
-		LineAttack(angle+pb_angle,75,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+		LineAttack(angle+pb_angle,75,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
 			pb_pufftype,
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
@@ -261,7 +261,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		
 		//pb_pufftype.roll=45;
 		
-		LineAttack(angle+pb_angle,75,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+		LineAttack(angle+pb_angle,75,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
 			"HDKharonPuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
@@ -357,7 +357,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		if(punchee.health>0)punchee.damagemobj(self,self,int(dmg),"SmallArms3");
 		//else HDF.Give(punchee,"SawGib",dmg*0.2);
 		
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
 			pb_pufftype,
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
@@ -527,7 +527,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		TNT1 A 0;
 		KRN5 BCD 2;
 	startfire:
-		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswingstart");
+		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerkswingstart");
 		KRN3 A 0 A_StartSound("weapons/pocket",CHAN_6);
 		KRN3 FEDCBA 2;
 		KRN3 C 0 A_WeaponBusy;
@@ -554,7 +554,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		TNT1 A 2 A_StartSound("weapons/pocket",CHAN_6);
 	goto holdswing;
 	swinghard:
-		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswinghard");
+		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerkswinghard");
 		KRN3 BDF 1;
 		TNT1 A 3;
 		#### A 0 A_Overlay(5,"hitcheck",false);

--- a/ZScript/Weapons/Melee/HDKharon.zsc
+++ b/ZScript/Weapons/Melee/HDKharon.zsc
@@ -243,17 +243,17 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		);
 		
 		//actual puff effect if the shot connects
-		/*LineAttack(angle+pb_angle,pb_range,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")>HDZERK_COOLOFF?"WallChunker":"WallChunker",
+		/*LineAttack(angle+pb_angle,pb_range,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")>PBZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>PBZERK_COOLOFF?"WallChunker":"WallChunker",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 			
-		LineAttack(angle+pb_angle,pb_range,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")>HDZERK_COOLOFF?"HDSmokeChunk":"BulletPuffSmall",
+		LineAttack(angle+pb_angle,pb_range,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")>PBZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>PBZERK_COOLOFF?"HDSmokeChunk":"BulletPuffSmall",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);*/
 		
-		LineAttack(angle+pb_angle,75,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+		LineAttack(angle+pb_angle,75,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")>PBZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
 			pb_pufftype,
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
@@ -261,7 +261,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		
 		//pb_pufftype.roll=45;
 		
-		LineAttack(angle+pb_angle,75,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+		LineAttack(angle+pb_angle,75,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")>PBZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
 			"HDKharonPuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
@@ -357,7 +357,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		if(punchee.health>0)punchee.damagemobj(self,self,int(dmg),"SmallArms3");
 		//else HDF.Give(punchee,"SawGib",dmg*0.2);
 		
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>PBZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
 			pb_pufftype,
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
@@ -527,7 +527,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		TNT1 A 0;
 		KRN5 BCD 2;
 	startfire:
-		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerkswingstart");
+		#### A 0 A_JumpIfInventory("HDZerk",PBZERK_COOLOFF,"zerkswingstart");
 		KRN3 A 0 A_StartSound("weapons/pocket",CHAN_6);
 		KRN3 FEDCBA 2;
 		KRN3 C 0 A_WeaponBusy;
@@ -554,7 +554,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		TNT1 A 2 A_StartSound("weapons/pocket",CHAN_6);
 	goto holdswing;
 	swinghard:
-		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerkswinghard");
+		#### A 0 A_JumpIfInventory("HDZerk",PBZERK_COOLOFF,"zerkswinghard");
 		KRN3 BDF 1;
 		TNT1 A 3;
 		#### A 0 A_Overlay(5,"hitcheck",false);

--- a/ZScript/Weapons/Melee/HDKnife.zsc
+++ b/ZScript/Weapons/Melee/HDKnife.zsc
@@ -173,8 +173,8 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 		if(!punchy)return;
 
 		//actual puff effect if the shot connects
-		LineAttack(angle,54,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")>HDZERK_COOLOFF?"BulletPuffMedium":"BulletPuffSmall",
+		LineAttack(angle,54,pitch,punchline.hitline?(countinv("HDZerk")>PBZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>PBZERK_COOLOFF?"BulletPuffMedium":"BulletPuffSmall",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
 		);
@@ -296,7 +296,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 	flick:
 		CKF0 A 1 offset(0,50) A_Lunge();
 		#### A 1 offset(0,36);
-		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"ZerkFlick");
+		#### A 0 A_JumpIfInventory("HDZerk",PBZERK_COOLOFF,"ZerkFlick");
 		#### AAAAAAA 0 A_CustomPunch((1),1,CPF_PULLIN,"HDFistPuncher",36);
 		goto flickend;
 	zerkflick:
@@ -311,7 +311,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 	hold:
 	althold:
 	startfire:
-		CKF0 A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerkpunch");
+		CKF0 A 0 A_JumpIfInventory("HDZerk",PBZERK_COOLOFF,"zerkpunch");
 		goto punch;
 	punch:
 		CKF0 C 1 offset(0,32) A_WeaponReady(WRF_NOSWITCH|WRF_NOFIRE);
@@ -339,7 +339,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 	lunge:
 		TNT1 A 0 A_Lunge();
 		TNT1 AA 1{
-			if(countinv("HDZerk")>HDZERK_COOLOFF)A_Recoil(-random(12,24));
+			if(countinv("HDZerk")>PBZERK_COOLOFF)A_Recoil(-random(12,24));
 		}
 		TNT1 A 1 A_Recoil(-4);
 	goto startfire;
@@ -377,7 +377,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 		loop;
 	
 	superstab:
-		CKF0 A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerksuperstab");
+		CKF0 A 0 A_JumpIfInventory("HDZerk",PBZERK_COOLOFF,"zerksuperstab");
 		CKF0 C 1 A_WeaponReady(WRF_NOSWITCH|WRF_NOFIRE);
 		#### D 0 {HDStab(6);hdplayerpawn(self).fatigue+=1;}
 		#### D 2 offset(-3,34);//A_WeaponOffset(frandom(-3,3),frandom(30,34));

--- a/ZScript/Weapons/Melee/HDKnife.zsc
+++ b/ZScript/Weapons/Melee/HDKnife.zsc
@@ -173,8 +173,8 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 		if(!punchy)return;
 
 		//actual puff effect if the shot connects
-		LineAttack(angle,54,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")?"BulletPuffMedium":"BulletPuffSmall",
+		LineAttack(angle,54,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>HDZERK_COOLOFF?"BulletPuffMedium":"BulletPuffSmall",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
 		);
@@ -296,7 +296,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 	flick:
 		CKF0 A 1 offset(0,50) A_Lunge();
 		#### A 1 offset(0,36);
-		#### A 0 A_JumpIfInventory("HDZerk",1,"ZerkFlick");
+		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"ZerkFlick");
 		#### AAAAAAA 0 A_CustomPunch((1),1,CPF_PULLIN,"HDFistPuncher",36);
 		goto flickend;
 	zerkflick:
@@ -311,7 +311,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 	hold:
 	althold:
 	startfire:
-		CKF0 A 0 A_JumpIfInventory("HDZerk",1,"zerkpunch");
+		CKF0 A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerkpunch");
 		goto punch;
 	punch:
 		CKF0 C 1 offset(0,32) A_WeaponReady(WRF_NOSWITCH|WRF_NOFIRE);
@@ -339,7 +339,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 	lunge:
 		TNT1 A 0 A_Lunge();
 		TNT1 AA 1{
-			if(countinv("HDZerk"))A_Recoil(-random(12,24));
+			if(countinv("HDZerk")>HDZERK_COOLOFF)A_Recoil(-random(12,24));
 		}
 		TNT1 A 1 A_Recoil(-4);
 	goto startfire;
@@ -377,7 +377,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 		loop;
 	
 	superstab:
-		CKF0 A 0 A_JumpIfInventory("HDZerk",1,"zerksuperstab");
+		CKF0 A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerksuperstab");
 		CKF0 C 1 A_WeaponReady(WRF_NOSWITCH|WRF_NOFIRE);
 		#### D 0 {HDStab(6);hdplayerpawn(self).fatigue+=1;}
 		#### D 2 offset(-3,34);//A_WeaponOffset(frandom(-3,3),frandom(30,34));

--- a/ZScript/Weapons/Melee/HDSledge.zsc
+++ b/ZScript/Weapons/Melee/HDSledge.zsc
@@ -208,18 +208,18 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 		//setweaponstate("Whoops");
 
 		//actual puff effect if the shot connects
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")>HDZERK_COOLOFF?"WallChunker":"WallChunker",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>PBZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>PBZERK_COOLOFF?"WallChunker":"WallChunker",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 			
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")>HDZERK_COOLOFF?"HDSmokeChunk":"BulletPuffSmall",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>PBZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>PBZERK_COOLOFF?"HDSmokeChunk":"BulletPuffSmall",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 		
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")>HDZERK_COOLOFF?"HDSledgePuff":"HDSledgePuff",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>PBZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>PBZERK_COOLOFF?"HDSledgePuff":"HDSledgePuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
 			
@@ -342,7 +342,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 	}
 	static void kick(actor kicker,actor kickee,actor kicking){
 		kickee.A_StartSound("weapons/smack",CHAN_BODY);
-		bool kzk=kicker.countinv("HDZerk")>HDZERK_COOLOFF;
+		bool kzk=kicker.countinv("HDZerk")>PBZERK_COOLOFF;
 		kickee.damagemobj(kicking,kicker,kzk?random(20,40):random(10,20),"bashing");
 		if(kickee&&!kickee.bnopain&&kickee.health>0&&random(0,4))kickee.setstatelabel("pain");
 		vector3 kickdir=(kickee.pos-kicker.pos).unit();
@@ -360,7 +360,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 	droop:
 		TNT1 A 1{
 			if(pitch<frandom(5,8)&&(!gunbraced())){
-				if(countinv("IsMoving")>2 && countinv("HDZerk")<HDZERK_COOLOFF){    
+				if(countinv("IsMoving")>2 && countinv("HDZerk")<PBZERK_COOLOFF){    
 					A_MuzzleClimb(frandom(-0.2,0.2),
 						frandom(0.1,clamp(1-pitch,0.1,0.3)));
 				}else{
@@ -422,7 +422,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 	althold:
 		TNT1 A 0;
 	startfire:
-		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerkswingstart");
+		#### A 0 A_JumpIfInventory("HDZerk",PBZERK_COOLOFF,"zerkswingstart");
 		SLH0 A 0 A_StartSound("weapons/pocket",CHAN_6);
 		//SLH0 A 0 A_WeaponBusy();
 		SLH0 B 3;
@@ -437,7 +437,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 		SLH0 D 2 offset(40,86);
 		TNT1 A 4 offset(-10,32);
 	bruh1:
-		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"bruh2");
+		#### A 0 A_JumpIfInventory("HDZerk",PBZERK_COOLOFF,"bruh2");
 		SLH0 EFGHIJKLMN 2 A_WeaponReady(WRF_NOFIRE|WRF_NOSWITCH);
 		SLH0 N 0 A_Overlay(3,"unf");
 		goto holdswing;
@@ -474,12 +474,12 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 	swingreturn:
 		TNT1 A 7;
 		TNT1 A 5 A_StartSound("weapons/pocket",CHAN_6);
-		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"bruh2");
+		#### A 0 A_JumpIfInventory("HDZerk",PBZERK_COOLOFF,"bruh2");
 		SLH0 EFGHIJKLMN 2;
 		SLH0 N 0 A_Overlay(3,"unf");
 	goto holdswing;
 	swing:
-		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerkswing");
+		#### A 0 A_JumpIfInventory("HDZerk",PBZERK_COOLOFF,"zerkswing");
 		#### A 0 
 		{
 		if(hdplayerpawn(self))hdplayerpawn(self).fatigue+=5;
@@ -548,7 +548,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 	lunge2:
 		TNT1 A 0 A_Lunge();
 		TNT1 AA 1{
-			if(countinv("HDZerk")>HDZERK_COOLOFF)A_Recoil(-random(12,24));
+			if(countinv("HDZerk")>PBZERK_COOLOFF)A_Recoil(-random(12,24));
 		}
 		TNT1 A 1 A_Recoil(-4);
 		stop;
@@ -576,7 +576,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 			flinetracedata ktl;
 			LineTrace(angle,radius*1.6,0,offsetz:10,data:ktl);
 			if(ktl.hitactor)invoker.kick(self,ktl.hitactor,invoker);
-			if(countinv("HDZerk")>HDZERK_COOLOFF)A_SetTics(8);
+			if(countinv("HDZerk")>PBZERK_COOLOFF)A_SetTics(8);
 		}
 		stop;
 	

--- a/ZScript/Weapons/Melee/HDSledge.zsc
+++ b/ZScript/Weapons/Melee/HDSledge.zsc
@@ -1,13 +1,6 @@
 // ------------------------------------------------------------
 // Sledgehammer
 // ------------------------------------------------------------
-/*class HDAxeHit:IdleDummy{
-	default{
-		+bloodlessimpact +nodecal +hittracer +puffonactors
-		stamina 1;
-	}
-}*/
-
 class HDSledgePuff:HDBulletPuff{
 	default{
 		stamina 5;scale 0.6;
@@ -72,7 +65,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 	bool washolding;
 	default{
 		//$Category "Weapons/Hideous Destructor"
-		//$Title "Fire Axe"
+		//$Title "Sledgehammer"
 		//$Sprite "SLH0Z0"
 		+WEAPON.MELEEWEAPON +WEAPON.NOALERT +WEAPON.NO_AUTO_SWITCH
 		+hdweapon.fitsinbackpack
@@ -215,18 +208,18 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 		//setweaponstate("Whoops");
 
 		//actual puff effect if the shot connects
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")?"WallChunker":"WallChunker",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>HDZERK_COOLOFF?"WallChunker":"WallChunker",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 			
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")?"HDSmokeChunk":"BulletPuffSmall",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>HDZERK_COOLOFF?"HDSmokeChunk":"BulletPuffSmall",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 		
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
-			countinv("HDZerk")?"HDSledgePuff":"HDSledgePuff",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")>HDZERK_COOLOFF?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")>HDZERK_COOLOFF?"HDSledgePuff":"HDSledgePuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
 			
@@ -348,8 +341,8 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 		A_Recoil(-3);
 	}
 	static void kick(actor kicker,actor kickee,actor kicking){
-		kickee.A_PlaySound("weapons/smack",CHAN_BODY);
-		bool kzk=kicker.countinv("HDZerk");
+		kickee.A_StartSound("weapons/smack",CHAN_BODY);
+		bool kzk=kicker.countinv("HDZerk")>HDZERK_COOLOFF;
 		kickee.damagemobj(kicking,kicker,kzk?random(20,40):random(10,20),"bashing");
 		if(kickee&&!kickee.bnopain&&kickee.health>0&&random(0,4))kickee.setstatelabel("pain");
 		vector3 kickdir=(kickee.pos-kicker.pos).unit();
@@ -367,7 +360,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 	droop:
 		TNT1 A 1{
 			if(pitch<frandom(5,8)&&(!gunbraced())){
-				if(countinv("IsMoving")>2 && countinv("HDZerk")<1){    
+				if(countinv("IsMoving")>2 && countinv("HDZerk")<HDZERK_COOLOFF){    
 					A_MuzzleClimb(frandom(-0.2,0.2),
 						frandom(0.1,clamp(1-pitch,0.1,0.3)));
 				}else{
@@ -429,7 +422,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 	althold:
 		TNT1 A 0;
 	startfire:
-		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswingstart");
+		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerkswingstart");
 		SLH0 A 0 A_StartSound("weapons/pocket",CHAN_6);
 		//SLH0 A 0 A_WeaponBusy();
 		SLH0 B 3;
@@ -444,7 +437,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 		SLH0 D 2 offset(40,86);
 		TNT1 A 4 offset(-10,32);
 	bruh1:
-		#### A 0 A_JumpIfInventory("HDZerk",1,"bruh2");
+		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"bruh2");
 		SLH0 EFGHIJKLMN 2 A_WeaponReady(WRF_NOFIRE|WRF_NOSWITCH);
 		SLH0 N 0 A_Overlay(3,"unf");
 		goto holdswing;
@@ -481,12 +474,12 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 	swingreturn:
 		TNT1 A 7;
 		TNT1 A 5 A_StartSound("weapons/pocket",CHAN_6);
-		#### A 0 A_JumpIfInventory("HDZerk",1,"bruh2");
+		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"bruh2");
 		SLH0 EFGHIJKLMN 2;
 		SLH0 N 0 A_Overlay(3,"unf");
 	goto holdswing;
 	swing:
-		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswing");
+		#### A 0 A_JumpIfInventory("HDZerk",HDZERK_COOLOFF,"zerkswing");
 		#### A 0 
 		{
 		if(hdplayerpawn(self))hdplayerpawn(self).fatigue+=5;
@@ -555,7 +548,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 	lunge2:
 		TNT1 A 0 A_Lunge();
 		TNT1 AA 1{
-			if(countinv("HDZerk"))A_Recoil(-random(12,24));
+			if(countinv("HDZerk")>HDZERK_COOLOFF)A_Recoil(-random(12,24));
 		}
 		TNT1 A 1 A_Recoil(-4);
 		stop;
@@ -583,7 +576,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 			flinetracedata ktl;
 			LineTrace(angle,radius*1.6,0,offsetz:10,data:ktl);
 			if(ktl.hitactor)invoker.kick(self,ktl.hitactor,invoker);
-			if(countinv("HDZerk"))A_SetTics(8);
+			if(countinv("HDZerk")>HDZERK_COOLOFF)A_SetTics(8);
 		}
 		stop;
 	

--- a/ZScript/Weapons/Microgun/BeltBox.zsc
+++ b/ZScript/Weapons/Microgun/BeltBox.zsc
@@ -74,7 +74,7 @@ class HD_PB_7mmBeltBox:HDMagAmmo{
 		)return false;
 		owner.A_TakeInventory(roundtype,1,TIF_NOTAKEINFINITE);
 		owner.A_TakeInventory("HD_776BeltLink",1,TIF_NOTAKEINFINITE);
-		owner.A_PlaySound("weapons/rifleclick2",CHAN_WEAPON);
+		owner.A_StartSound("weapons/rifleclick2",CHAN_WEAPON);
 		mags[mags.size()-1]++;
 		
 			inserttime=11;

--- a/ZScript/Weapons/SteyrACR/SteyrGun.zsc
+++ b/ZScript/Weapons/SteyrACR/SteyrGun.zsc
@@ -93,7 +93,7 @@ class HD_SteyrACR:HDWeapon{
 		HDStatusBar sb,HDWeapon hdw,HDPlayerPawn hpl,
 		bool sightbob,vector2 bob,double fov,bool scopeview,actor hpc,string whichdot
 	){
-		int scaledyoffset=41.9;
+		float scaledyoffset=41.9;
 		if(hdw.weaponstatus[0]&ZM66F_GLMODE)sb.drawgrenadeladder(hdw.airburst,bob);
 		else{
 		vector2 bobb=bob*1.25;


### PR DESCRIPTION
This also fixes the transfer specials error with the full auto .50AM Pistol that I noticed while playing around with Consolation Prize: Doom 64.