### PR TITLE
Additional sight fixes

### DIFF
--- a/ZScript/Weapons/5mmGuns/A180/A180.zsc
+++ b/ZScript/Weapons/5mmGuns/A180/A180.zsc
@@ -95,11 +95,11 @@ class HD_M5165:HDWeapon{
 		int cx,cy,cw,ch;
 		[cx,cy,cw,ch]=screen.GetClipRect();
 		sb.SetClipRect(
-			-16+bob.x,-32+bob.y,32,40,
+			-16+bob.x,-32+bob.y,32,50,
 			sb.DI_SCREEN_CENTER
 		);
-		vector2 bobb=bob*1.1;
-		bobb.y=clamp(bobb.y,-1,1);
+		vector2 bobb=bob*1.2;
+		//bobb.y=clamp(bobb.y,-1,1);
 		sb.drawimage(
 			"A18S_001",(0,0.9)+bobb,sb.DI_SCREEN_CENTER|sb.DI_ITEM_TOP,
 			alpha:0.9,scale:(0.9,0.9)

--- a/ZScript/Weapons/Kelenken/Kelenken.zsc
+++ b/ZScript/Weapons/Kelenken/Kelenken.zsc
@@ -53,10 +53,10 @@ class HD_ATCKelenken:HDWeapon{
 	){
 			int scaledyoffset=47;
 			double dotoff=max(abs(bob.x),abs(bob.y));
-			if(dotoff<20){
+			if(dotoff<30){
 				sb.drawimage(
-					whichdot,(0,0)+bob*1.6,sb.DI_SCREEN_CENTER|sb.DI_ITEM_CENTER,
-					alpha:0.8-dotoff*0.04
+					whichdot,(0,0)+bob*1.18,sb.DI_SCREEN_CENTER|sb.DI_ITEM_CENTER,
+					alpha:0.8-dotoff*0.01
 				);
 			}
 			sb.drawimage(

--- a/ZScript/Weapons/LeverGun/Levergat.zsc
+++ b/ZScript/Weapons/LeverGun/Levergat.zsc
@@ -86,7 +86,7 @@ class HDLeverGun:HDWeapon{
 			sb.DI_SCREEN_CENTER
 		);
 		vector2 bobb=bob*1.1;
-		bobb.y=clamp(bobb.y,-8,8);
+		//bobb.y=clamp(bobb.y,-8,8);
 		if(hdw.WeaponStatus[LEVS_SCOPE])
 		{
 		sb.drawimage(

--- a/ZScript/Weapons/Railgun/PWRailgun.zsc
+++ b/ZScript/Weapons/Railgun/PWRailgun.zsc
@@ -86,8 +86,8 @@ class HDFortuneRailgun:HDWeapon{
 		);
 		int scaledyoffset=36;
 	
-		vector2 bobb=bob*2;
-		bobb.y=clamp(bobb.y,-8,8);
+		vector2 bobb=bob*1.1;
+		//bobb.y=clamp(bobb.y,-8,8);
 		sb.drawimage(
 			"frntsite",(0,0)+bobb,sb.DI_SCREEN_CENTER|sb.DI_ITEM_TOP,
 			alpha:0.9,scale:(1.6,2)


### PR DESCRIPTION
The Kelenken and Railgun never got their bobbing corrected, and the levergun and A180 had leftover vertical clamps. I also increased the bobbing on the A180 a little bit, because it looked almost completely static at 1.1 after removing the clamp.